### PR TITLE
Handle [package ...] arguments like most Go tools.

### DIFF
--- a/maligned.go
+++ b/maligned.go
@@ -14,6 +14,7 @@ import (
 	"log"
 	"sort"
 
+	"github.com/kisielk/gotool"
 	"golang.org/x/tools/go/loader"
 )
 
@@ -22,10 +23,15 @@ var fset = token.NewFileSet()
 func main() {
 	flag.Parse()
 
+	importPaths := gotool.ImportPaths(flag.Args())
+	if len(importPaths) == 0 {
+		return
+	}
+
 	var conf loader.Config
 	conf.Fset = fset
-	for _, arg := range flag.Args() {
-		conf.Import(arg)
+	for _, importPath := range importPaths {
+		conf.Import(importPath)
 	}
 	prog, err := conf.Load()
 	if err != nil {


### PR DESCRIPTION
Support import path patterns, including within relative import paths.
When given 0 arguments, use the package in current working directory.
If the import path patterns match no packages, print a warning and exit with 0 exit code.

Rely on go/loader to resolve relative import paths relative to current working directory.

Fixes #4.

Similar to mdempsky/unconvert#9.
