### PR TITLE
maligned: use runtime.GOARCH to determine type sizes

### DIFF
--- a/maligned.go
+++ b/maligned.go
@@ -29,6 +29,7 @@ func main() {
 	}
 
 	var conf loader.Config
+	conf.TypeChecker.Sizes = types.SizesFor(build.Default.Compiler, build.Default.GOARCH)
 	conf.Fset = fset
 	for _, importPath := range importPaths {
 		conf.Import(importPath)


### PR DESCRIPTION
This arose while porting @cznic's crt to linux_arm. See https://github.com/cznic/crt/pull/3

Please take a look.